### PR TITLE
First weekday

### DIFF
--- a/RSDayFlow/RSDFDatePickerView.m
+++ b/RSDayFlow/RSDFDatePickerView.m
@@ -498,6 +498,15 @@ static const CGFloat RSDFDatePickerViewDaysOfWeekViewHeight = 22.0f;
 	};
 }
 
+- (NSUInteger)weekdayOrderForWeekdayNumber:(NSUInteger)weekday {
+    NSInteger ordered = weekday - (self.calendar.firstWeekday - 1);
+    if (ordered < 1) {
+        ordered = 7 - ABS(ordered);
+    }
+    
+    return ordered;
+}
+
 #pragma mark - UICollectionViewDataSource
 
 - (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView
@@ -508,15 +517,6 @@ static const CGFloat RSDFDatePickerViewDaysOfWeekViewHeight = 22.0f;
 - (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section
 {
 	return self.daysInWeek * [self numberOfWeeksForMonthOfDate:[self dateForFirstDayInSection:section]];
-}
-
-- (NSUInteger)weekdayOrderForWeekdayNumber:(NSUInteger)weekday {
-    NSInteger ordered = weekday - (self.calendar.firstWeekday - 1);
-    if (ordered < 1) {
-        ordered = 7 - ABS(ordered);
-    }
-    
-    return ordered;
 }
 
 - (RSDFDatePickerDayCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
Hi Ruslan, 

Thank you for your work on this widget. I really like his easiness and functional. 
One thing I noted where I trying to setup Monday as first weekday - some months has a wrong day order. 
You can see it here, July 1 disappeared : 
![2014-10-08 18-25-57 ios simulator - iphone 6 - iphone 6 ios 8 0 12a365](https://cloud.githubusercontent.com/assets/5666720/4560828/03eacb14-4ef8-11e4-9c0d-c24fe5b0b100.png)

So this pull request contain fast fix for this, please have a look. 
![2014-10-08 18-27-09 ios simulator - iphone 6 - iphone 6 ios 8 0 12a365](https://cloud.githubusercontent.com/assets/5666720/4560827/03e41c38-4ef8-11e4-85b4-84e575634fd5.png)

It should work for any weekday as first day. I test it only for Gregorian, so not sure how it will affect other calendars types. 

Again, thank you
