### PR TITLE
Issue 61

### DIFF
--- a/Example/RSDayFlowExample/RSDFCustomDatePickerDayCell.m
+++ b/Example/RSDayFlowExample/RSDFCustomDatePickerDayCell.m
@@ -92,19 +92,6 @@
     return [UIColor clearColor];
 }
 
--(UIImage *)customCompleteMarkImage{
-    
-    CGRect frame = CGRectMake(0, 0, 35.0f, 35.0f);
-    UIGraphicsBeginImageContextWithOptions(frame.size, NO, self.window.screen.scale);
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    CGContextSetFillColorWithColor(context, [UIColor clearColor].CGColor);
-    CGContextFillEllipseInRect(context, frame);
-    CGContextSetStrokeColorWithColor(context, [UIColor redColor].CGColor);
-    CGContextSetLineWidth(context, 2.0);
-    CGContextStrokeEllipseInRect(context, CGRectInset(frame, 1, 1));
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    return image;
-}
+
 
 @end

--- a/Example/RSDayFlowExample/RSDFCustomDatePickerDayCell.m
+++ b/Example/RSDayFlowExample/RSDFCustomDatePickerDayCell.m
@@ -92,4 +92,19 @@
     return [UIColor clearColor];
 }
 
+-(UIImage *)customCompleteMarkImage{
+    
+    CGRect frame = CGRectMake(0, 0, 35.0f, 35.0f);
+    UIGraphicsBeginImageContextWithOptions(frame.size, NO, self.window.screen.scale);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextSetFillColorWithColor(context, [UIColor clearColor].CGColor);
+    CGContextFillEllipseInRect(context, frame);
+    CGContextSetStrokeColorWithColor(context, [UIColor redColor].CGColor);
+    CGContextSetLineWidth(context, 2.0);
+    CGContextStrokeEllipseInRect(context, CGRectInset(frame, 1, 1));
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return image;
+}
+
 @end

--- a/Example/RSDayFlowExample/RSDFDatePickerViewController.m
+++ b/Example/RSDayFlowExample/RSDFDatePickerViewController.m
@@ -31,6 +31,7 @@
 
 @property (strong, nonatomic) NSArray *datesToMark;
 @property (strong, nonatomic) NSDictionary *statesOfTasks;
+@property (strong, nonatomic) NSMutableSet *squareDates;
 @property (strong, nonatomic) NSDateFormatter *dateFormatter;
 @property (strong, nonatomic) RSDFDatePickerView *datePickerView;
 @property (strong, nonatomic) RSDFCustomDatePickerView *customDatePickerView;
@@ -44,6 +45,8 @@
 - (void)viewDidLoad
 {
 	[super viewDidLoad];
+    
+    self.squareDates = [[NSMutableSet alloc] init];
 	
     self.edgesForExtendedLayout = UIRectEdgeNone;
     self.automaticallyAdjustsScrollViewInsets = NO;
@@ -120,6 +123,7 @@
             // Add custom color
             color = [UIColor yellowColor];
             if ([date compare:today] == NSOrderedAscending) {
+                [self.squareDates addObject:date];
                 color = [UIColor greenColor];
             }
             statesOfTasks[date] = color;
@@ -203,11 +207,55 @@
 
 
 - (UIColor *)datePickerView:(RSDFDatePickerView *)view markImageColorForDate:(NSDate *)date{
+    
+    if ([[self class] dateIsWeekend:date]) {
+        return [UIColor blackColor];
+    }
+    
     return self.statesOfTasks[date];
 }
 
 -(UIImage *)datePickerView:(RSDFDatePickerView *)view markImageFoDate:(NSDate *)date{
-    return nil;
+    
+    if ([self.squareDates containsObject:date]) {
+        NSLog(@"Entered Square");
+        CGRect frame = CGRectMake(0, 0, 12.0f, 12.0f);
+        UIGraphicsBeginImageContextWithOptions(frame.size, NO, 0);
+        CGContextRef context = UIGraphicsGetCurrentContext();
+        CGContextSetFillColorWithColor(context, [UIColor clearColor].CGColor);
+        CGContextFillRect(context, frame);
+        CGContextSetStrokeColorWithColor(context, [UIColor redColor].CGColor);
+        CGContextSetLineWidth(context, 2.0);
+        CGContextStrokeRect(context, frame);
+        UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+        return image;
+    } else{
+        CGRect frame = CGRectMake(0, 0, 12.0f, 12.0f);
+        UIGraphicsBeginImageContextWithOptions(frame.size, NO, 0);
+        CGContextRef context = UIGraphicsGetCurrentContext();
+        CGContextSetFillColorWithColor(context, [UIColor clearColor].CGColor);
+        CGContextFillEllipseInRect(context, frame);
+        CGContextSetStrokeColorWithColor(context, [UIColor redColor].CGColor);
+        CGContextSetLineWidth(context, 2.0);
+        CGContextStrokeEllipseInRect(context, CGRectInset(frame, 1, 1));
+        UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+        return image;
+    }
+}
+
++(BOOL)dateIsWeekend:(NSDate *)date{
+    NSCalendar *calender = [NSCalendar currentCalendar];
+    NSRange weekdayRange = [calender maximumRangeOfUnit:NSWeekdayCalendarUnit];
+    NSDateComponents *components = [calender components:NSWeekdayCalendarUnit fromDate:date];
+    NSUInteger weekdayDate = [components weekday];
+    
+    if (weekdayDate == weekdayRange.location || weekdayDate == weekdayRange.length) {
+        return YES;
+    }
+    
+    return NO;
 }
 
 @end

--- a/Example/RSDayFlowExample/RSDFDatePickerViewController.m
+++ b/Example/RSDayFlowExample/RSDFDatePickerViewController.m
@@ -201,13 +201,13 @@
     return [self.datesToMark containsObject:date];
 }
 
-- (BOOL)datePickerView:(RSDFDatePickerView *)view isCompletedAllTasksOnDate:(NSDate *)date
-{
-	return [self.statesOfTasks[date] boolValue];
-}
 
 - (UIColor *)datePickerView:(RSDFDatePickerView *)view markImageColorForDate:(NSDate *)date{
     return self.statesOfTasks[date];
+}
+
+-(UIImage *)datePickerView:(RSDFDatePickerView *)view markImageFoDate:(NSDate *)date{
+    return nil;
 }
 
 @end

--- a/Example/RSDayFlowExample/RSDFDatePickerViewController.m
+++ b/Example/RSDayFlowExample/RSDFDatePickerViewController.m
@@ -109,17 +109,20 @@
 
 - (NSDictionary *)statesOfTasks
 {
+    __block UIColor *color;
+    
     if (!_statesOfTasks) {
         NSDateComponents *todayComponents = [self.calendar components:(NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay) fromDate:[NSDate date]];
         NSDate *today = [self.calendar dateFromComponents:todayComponents];
         
         NSMutableDictionary *statesOfTasks = [[NSMutableDictionary alloc] initWithCapacity:[self.datesToMark count]];
         [self.datesToMark enumerateObjectsUsingBlock:^(NSDate *date, NSUInteger idx, BOOL *stop) {
-            BOOL isCompletedAllTasks = NO;
+            // Add custom color
+            color = [UIColor yellowColor];
             if ([date compare:today] == NSOrderedAscending) {
-                isCompletedAllTasks = YES;
+                color = [UIColor greenColor];
             }
-            statesOfTasks[date] = @(isCompletedAllTasks);
+            statesOfTasks[date] = color;
         }];
         
         _statesOfTasks = [statesOfTasks copy];
@@ -201,6 +204,10 @@
 - (BOOL)datePickerView:(RSDFDatePickerView *)view isCompletedAllTasksOnDate:(NSDate *)date
 {
 	return [self.statesOfTasks[date] boolValue];
+}
+
+- (UIColor *)datePickerView:(RSDFDatePickerView *)view markImageColorForDate:(NSDate *)date{
+    return self.statesOfTasks[date];
 }
 
 @end

--- a/RSDayFlow/RSDFDatePickerDayCell.h
+++ b/RSDayFlow/RSDFDatePickerDayCell.h
@@ -76,6 +76,11 @@
  */
 @property (nonatomic, getter = isCompleted) BOOL completed;
 
+/**
+ A color denoting a custom color for date
+ */
+@property (nonatomic) UIColor *customColor;
+
 ///---------------------------------------
 /// @name Accessing Attributes of the View
 ///---------------------------------------

--- a/RSDayFlow/RSDFDatePickerDayCell.h
+++ b/RSDayFlow/RSDFDatePickerDayCell.h
@@ -81,6 +81,11 @@
  */
 @property (nonatomic) UIColor *customColor;
 
+/**
+ An Image to be used assigned by datasource
+ */
+@property (nonatomic) UIImage *customImage;
+
 ///---------------------------------------
 /// @name Accessing Attributes of the View
 ///---------------------------------------

--- a/RSDayFlow/RSDFDatePickerDayCell.m
+++ b/RSDayFlow/RSDFDatePickerDayCell.m
@@ -204,11 +204,7 @@
             }
         }
         
-        if (!self.isCompleted) {
-            self.markImageView.image = [self incompleteMarkImage];
-        } else {
-            self.markImageView.image = [self completeMarkImage];
-        }
+        self.markImageView.image = [self completeMarkImage];
     }
 }
 
@@ -426,10 +422,15 @@
 {
     UIImage *completeMarkImage = [self customCompleteMarkImage];
     if (!completeMarkImage) {
-        UIColor *completeMarkImageColor = [self completeMarkImageColor];
+        UIColor *completeMarkImageColor = self.customColor;
+        if (!self.customColor) {
+            self.customColor = [self completeMarkImageColor];
+        }
         NSString *completeMarkImageKey = [NSString stringWithFormat:@"img_mark_%@", [completeMarkImageColor description]];
         completeMarkImage = [self ellipseImageWithKey:completeMarkImageKey frame:self.markImageView.frame color:completeMarkImageColor];
     }
+    
+    
     return completeMarkImage;
 }
 

--- a/RSDayFlow/RSDFDatePickerDayCell.m
+++ b/RSDayFlow/RSDFDatePickerDayCell.m
@@ -443,14 +443,17 @@
 - (UIImage *)completeMarkImage
 {
     UIImage *completeMarkImage = [self customCompleteMarkImage];
-        if (!completeMarkImage) {
-            UIColor *completeMarkImageColor = self.customColor;
-            if (!self.customColor) {
-                self.customColor = [self completeMarkImageColor];
+    if (!completeMarkImage) {
+        completeMarkImage = self.customImage;
+            if (!completeMarkImage) {
+                UIColor *completeMarkImageColor = self.customColor;
+                if (!self.customColor) {
+                    self.customColor = [self completeMarkImageColor];
+                }
+                NSString *completeMarkImageKey = [NSString stringWithFormat:@"img_mark_%@", [completeMarkImageColor description]];
+                completeMarkImage = [self ellipseImageWithKey:completeMarkImageKey frame:self.markImageView.frame color:completeMarkImageColor];
             }
-            NSString *completeMarkImageKey = [NSString stringWithFormat:@"img_mark_%@", [completeMarkImageColor description]];
-            completeMarkImage = [self ellipseImageWithKey:completeMarkImageKey frame:self.markImageView.frame color:completeMarkImageColor];
-        }
+    }
     
     return [[self class] newImageFromMaskImage:completeMarkImage inColor:self.customColor];
 }

--- a/RSDayFlow/RSDFDatePickerView.h
+++ b/RSDayFlow/RSDFDatePickerView.h
@@ -233,4 +233,21 @@
  */
 - (BOOL)datePickerView:(RSDFDatePickerView *)view isCompletedAllTasksOnDate:(NSDate *)date;
 
+/**
+ Asks the data source for the image to show for marked date
+ 
+ @param view The date picker view object that is asking about the completion of tasks on the date.
+ 
+ @return UIImage for marked date
+ */
+-(UIImage *)datePickerView:(RSDFDatePickerView *)view markImageFoDate:(NSDate *)date;
+
+/**
+ 
+ @param view The date picker view object that is asking about the completion of tasks on the date.
+ 
+ @return UIColor for marked date
+*/
+-(UIColor *)datePickerView:(RSDFDatePickerView *)view markImageColorForDate:(NSDate *)date;
+
 @end

--- a/RSDayFlow/RSDFDatePickerView.m
+++ b/RSDayFlow/RSDFDatePickerView.m
@@ -642,6 +642,10 @@ static NSString * const RSDFDatePickerViewDayCellIdentifier = @"RSDFDatePickerVi
             if (cell.marked && [self.dataSource respondsToSelector:@selector(datePickerView:markImageColorForDate:)]) {
                 cell.customColor = [self.dataSource datePickerView:self markImageColorForDate:cellDate];
             }
+            
+            if (cell.marked && [self.dataSource respondsToSelector:@selector(datePickerView:markImageFoDate:)]) {
+                cell.customImage = [self.dataSource datePickerView:self markImageFoDate:cellDate];
+            }
         }
         
         cell.today = ([cellDate compare:_today] == NSOrderedSame) ? YES : NO;

--- a/RSDayFlow/RSDFDatePickerView.m
+++ b/RSDayFlow/RSDFDatePickerView.m
@@ -639,8 +639,8 @@ static NSString * const RSDFDatePickerViewDayCellIdentifier = @"RSDFDatePickerVi
         if ([self.dataSource respondsToSelector:@selector(datePickerView:shouldMarkDate:)]) {
             cell.marked = [self.dataSource datePickerView:self shouldMarkDate:cellDate];
             
-            if (cell.marked && [self.dataSource respondsToSelector:@selector(datePickerView:isCompletedAllTasksOnDate:)]) {
-                cell.completed = [self.dataSource datePickerView:self isCompletedAllTasksOnDate:cellDate];
+            if (cell.marked && [self.dataSource respondsToSelector:@selector(datePickerView:markImageColorForDate:)]) {
+                cell.customColor = [self.dataSource datePickerView:self markImageColorForDate:cellDate];
             }
         }
         


### PR DESCRIPTION
Hi @ruslanskorb here's a PR relating to Issue 61.

It implements two datasource methods to flag colours and images for dates

```-(UIImage *)datePickerView:(RSDFDatePickerView *)view markImageFoDate:(NSDate *)date```
```- (UIColor *)datePickerView:(RSDFDatePickerView *)view markImageColorForDate:(NSDate *)date```

I wonder would there still be a need to provide ```-(UIImage *)customCompleteMarkImage``` functionaliy on the RSDatePickerViewCell?

Any thoughts? :smiley: 

![img_1592](https://cloud.githubusercontent.com/assets/5772795/6886409/324973e2-d635-11e4-9e4c-63cb289d9a36.PNG)
