### PR TITLE
Account for different firstWeekday in Days Of Week View text colors

### DIFF
--- a/RSDayFlow/RSDFDatePickerDaysOfWeekView.m
+++ b/RSDayFlow/RSDFDatePickerDaysOfWeekView.m
@@ -229,7 +229,9 @@
                 weekdayLabel.textAlignment = NSTextAlignmentCenter;
                 weekdayLabel.backgroundColor = dayOfWeekLabelBackgroundColor;
                 weekdayLabel.font = dayOfWeekLabelFont;
-                if ([symbolsToUse indexOfObjectIdenticalTo:weekdaySymbol] != 0 && [symbolsToUse indexOfObjectIdenticalTo:weekdaySymbol] != 6) {
+
+                NSInteger firstDayOfWeekOffset = [self.calendar firstWeekday] - 1;
+                if (([symbolsToUse indexOfObjectIdenticalTo:weekdaySymbol] + firstDayOfWeekOffset) % 7 != 0 && ([symbolsToUse indexOfObjectIdenticalTo:weekdaySymbol] + firstDayOfWeekOffset) % 7 != 6) {
                     weekdayLabel.textColor = dayOfWeekLabelTextColor;
                 } else {
                     weekdayLabel.textColor = dayOffOfWeekLabelTextColor;


### PR DESCRIPTION
With Locales that start the week with Monday, the wrong weekdays get a grey text color. See attached screenshot. This pull request uses an offset according to the calendar firstWeekdayto fix this.
![simulator screen shot 15 sep 2015 06 40 01](https://cloud.githubusercontent.com/assets/826126/9869727/9bb1f49a-5b86-11e5-8204-63f67f0b4619.png)