### PR TITLE
Set date on month header after setting the text

### DIFF
--- a/RSDayFlow/RSDFDatePickerView.m
+++ b/RSDayFlow/RSDFDatePickerView.m
@@ -725,12 +725,12 @@ static NSString * const RSDFDatePickerViewDayCellIdentifier = @"RSDFDatePickerVi
         
         NSDate *formattedDate = [self dateForFirstDayInSection:indexPath.section];
         RSDFDatePickerDate date = [self pickerDateFromDate:formattedDate];
-        
-        monthHeader.date = date;
-        
+
         NSString *monthString = [dateFormatter shortStandaloneMonthSymbols][date.month - 1];
         monthHeader.dateLabel.text = [[NSString stringWithFormat:@"%@ %tu", monthString, date.year] uppercaseString];
         
+        monthHeader.date = date;
+
         RSDFDatePickerDate today = [self pickerDateFromDate:_today];
         if ( (today.month == date.month) && (today.year == date.year) ) {
             monthHeader.currentMonth = YES;


### PR DESCRIPTION
I would like to use a custom text in a custom subclass of RSDFDatePickerMonthHeader. This PR sets the date on the month header after setting the text to allow overriding the date property and setting the text from there.