### PR TITLE
Add support for Carthage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RSDayFlow [![Build Status](https://travis-ci.org/ruslanskorb/RSDayFlow.svg)](https://travis-ci.org/ruslanskorb/RSDayFlow)
+# RSDayFlow [![Build Status](https://travis-ci.org/ruslanskorb/RSDayFlow.svg)](https://travis-ci.org/ruslanskorb/RSDayFlow) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 <p align="center">
 	<img src="Screenshot.png" alt="Sample">

--- a/RSDayFlow.xcodeproj/project.pbxproj
+++ b/RSDayFlow.xcodeproj/project.pbxproj
@@ -1,0 +1,348 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		BC149D1C1BBC12A3008D033B /* RSDayFlow.h in Headers */ = {isa = PBXBuildFile; fileRef = BC149D1B1BBC12A3008D033B /* RSDayFlow.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BC149D331BBC12EA008D033B /* NSCalendar+RSDFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = BC149D231BBC12EA008D033B /* NSCalendar+RSDFAdditions.h */; settings = {ASSET_TAGS = (); }; };
+		BC149D341BBC12EA008D033B /* NSCalendar+RSDFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = BC149D241BBC12EA008D033B /* NSCalendar+RSDFAdditions.m */; settings = {ASSET_TAGS = (); }; };
+		BC149D351BBC12EA008D033B /* RSDFDatePickerCollectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = BC149D251BBC12EA008D033B /* RSDFDatePickerCollectionView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BC149D361BBC12EA008D033B /* RSDFDatePickerCollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = BC149D261BBC12EA008D033B /* RSDFDatePickerCollectionView.m */; settings = {ASSET_TAGS = (); }; };
+		BC149D371BBC12EA008D033B /* RSDFDatePickerCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = BC149D271BBC12EA008D033B /* RSDFDatePickerCollectionViewLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BC149D381BBC12EA008D033B /* RSDFDatePickerCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = BC149D281BBC12EA008D033B /* RSDFDatePickerCollectionViewLayout.m */; settings = {ASSET_TAGS = (); }; };
+		BC149D391BBC12EA008D033B /* RSDFDatePickerDate.h in Headers */ = {isa = PBXBuildFile; fileRef = BC149D291BBC12EA008D033B /* RSDFDatePickerDate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BC149D3A1BBC12EA008D033B /* RSDFDatePickerDayCell.h in Headers */ = {isa = PBXBuildFile; fileRef = BC149D2A1BBC12EA008D033B /* RSDFDatePickerDayCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BC149D3B1BBC12EA008D033B /* RSDFDatePickerDayCell.m in Sources */ = {isa = PBXBuildFile; fileRef = BC149D2B1BBC12EA008D033B /* RSDFDatePickerDayCell.m */; settings = {ASSET_TAGS = (); }; };
+		BC149D3C1BBC12EA008D033B /* RSDFDatePickerDaysOfWeekView.h in Headers */ = {isa = PBXBuildFile; fileRef = BC149D2C1BBC12EA008D033B /* RSDFDatePickerDaysOfWeekView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BC149D3D1BBC12EA008D033B /* RSDFDatePickerDaysOfWeekView.m in Sources */ = {isa = PBXBuildFile; fileRef = BC149D2D1BBC12EA008D033B /* RSDFDatePickerDaysOfWeekView.m */; settings = {ASSET_TAGS = (); }; };
+		BC149D3E1BBC12EA008D033B /* RSDFDatePickerMonthHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = BC149D2E1BBC12EA008D033B /* RSDFDatePickerMonthHeader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BC149D3F1BBC12EA008D033B /* RSDFDatePickerMonthHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = BC149D2F1BBC12EA008D033B /* RSDFDatePickerMonthHeader.m */; settings = {ASSET_TAGS = (); }; };
+		BC149D401BBC12EA008D033B /* RSDFDatePickerView.h in Headers */ = {isa = PBXBuildFile; fileRef = BC149D301BBC12EA008D033B /* RSDFDatePickerView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BC149D411BBC12EA008D033B /* RSDFDatePickerView.m in Sources */ = {isa = PBXBuildFile; fileRef = BC149D311BBC12EA008D033B /* RSDFDatePickerView.m */; settings = {ASSET_TAGS = (); }; };
+		BC149D421BBC12EA008D033B /* RSDFDatePickerView+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = BC149D321BBC12EA008D033B /* RSDFDatePickerView+Protected.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		BC149D181BBC12A3008D033B /* RSDayFlow.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RSDayFlow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BC149D1B1BBC12A3008D033B /* RSDayFlow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RSDayFlow.h; sourceTree = "<group>"; };
+		BC149D1D1BBC12A3008D033B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BC149D231BBC12EA008D033B /* NSCalendar+RSDFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSCalendar+RSDFAdditions.h"; sourceTree = "<group>"; };
+		BC149D241BBC12EA008D033B /* NSCalendar+RSDFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSCalendar+RSDFAdditions.m"; sourceTree = "<group>"; };
+		BC149D251BBC12EA008D033B /* RSDFDatePickerCollectionView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RSDFDatePickerCollectionView.h; sourceTree = "<group>"; };
+		BC149D261BBC12EA008D033B /* RSDFDatePickerCollectionView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RSDFDatePickerCollectionView.m; sourceTree = "<group>"; };
+		BC149D271BBC12EA008D033B /* RSDFDatePickerCollectionViewLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RSDFDatePickerCollectionViewLayout.h; sourceTree = "<group>"; };
+		BC149D281BBC12EA008D033B /* RSDFDatePickerCollectionViewLayout.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RSDFDatePickerCollectionViewLayout.m; sourceTree = "<group>"; };
+		BC149D291BBC12EA008D033B /* RSDFDatePickerDate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RSDFDatePickerDate.h; sourceTree = "<group>"; };
+		BC149D2A1BBC12EA008D033B /* RSDFDatePickerDayCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RSDFDatePickerDayCell.h; sourceTree = "<group>"; };
+		BC149D2B1BBC12EA008D033B /* RSDFDatePickerDayCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RSDFDatePickerDayCell.m; sourceTree = "<group>"; };
+		BC149D2C1BBC12EA008D033B /* RSDFDatePickerDaysOfWeekView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RSDFDatePickerDaysOfWeekView.h; sourceTree = "<group>"; };
+		BC149D2D1BBC12EA008D033B /* RSDFDatePickerDaysOfWeekView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RSDFDatePickerDaysOfWeekView.m; sourceTree = "<group>"; };
+		BC149D2E1BBC12EA008D033B /* RSDFDatePickerMonthHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RSDFDatePickerMonthHeader.h; sourceTree = "<group>"; };
+		BC149D2F1BBC12EA008D033B /* RSDFDatePickerMonthHeader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RSDFDatePickerMonthHeader.m; sourceTree = "<group>"; };
+		BC149D301BBC12EA008D033B /* RSDFDatePickerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RSDFDatePickerView.h; sourceTree = "<group>"; };
+		BC149D311BBC12EA008D033B /* RSDFDatePickerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RSDFDatePickerView.m; sourceTree = "<group>"; };
+		BC149D321BBC12EA008D033B /* RSDFDatePickerView+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RSDFDatePickerView+Protected.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		BC149D141BBC12A3008D033B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		BC149D0E1BBC12A3008D033B = {
+			isa = PBXGroup;
+			children = (
+				BC149D1A1BBC12A3008D033B /* RSDayFlow */,
+				BC149D191BBC12A3008D033B /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		BC149D191BBC12A3008D033B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				BC149D181BBC12A3008D033B /* RSDayFlow.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		BC149D1A1BBC12A3008D033B /* RSDayFlow */ = {
+			isa = PBXGroup;
+			children = (
+				BC149D1D1BBC12A3008D033B /* Info.plist */,
+				BC149D231BBC12EA008D033B /* NSCalendar+RSDFAdditions.h */,
+				BC149D241BBC12EA008D033B /* NSCalendar+RSDFAdditions.m */,
+				BC149D1B1BBC12A3008D033B /* RSDayFlow.h */,
+				BC149D251BBC12EA008D033B /* RSDFDatePickerCollectionView.h */,
+				BC149D261BBC12EA008D033B /* RSDFDatePickerCollectionView.m */,
+				BC149D271BBC12EA008D033B /* RSDFDatePickerCollectionViewLayout.h */,
+				BC149D281BBC12EA008D033B /* RSDFDatePickerCollectionViewLayout.m */,
+				BC149D291BBC12EA008D033B /* RSDFDatePickerDate.h */,
+				BC149D2A1BBC12EA008D033B /* RSDFDatePickerDayCell.h */,
+				BC149D2B1BBC12EA008D033B /* RSDFDatePickerDayCell.m */,
+				BC149D2C1BBC12EA008D033B /* RSDFDatePickerDaysOfWeekView.h */,
+				BC149D2D1BBC12EA008D033B /* RSDFDatePickerDaysOfWeekView.m */,
+				BC149D2E1BBC12EA008D033B /* RSDFDatePickerMonthHeader.h */,
+				BC149D2F1BBC12EA008D033B /* RSDFDatePickerMonthHeader.m */,
+				BC149D301BBC12EA008D033B /* RSDFDatePickerView.h */,
+				BC149D311BBC12EA008D033B /* RSDFDatePickerView.m */,
+				BC149D321BBC12EA008D033B /* RSDFDatePickerView+Protected.h */,
+			);
+			path = RSDayFlow;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		BC149D151BBC12A3008D033B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BC149D3C1BBC12EA008D033B /* RSDFDatePickerDaysOfWeekView.h in Headers */,
+				BC149D351BBC12EA008D033B /* RSDFDatePickerCollectionView.h in Headers */,
+				BC149D391BBC12EA008D033B /* RSDFDatePickerDate.h in Headers */,
+				BC149D3E1BBC12EA008D033B /* RSDFDatePickerMonthHeader.h in Headers */,
+				BC149D401BBC12EA008D033B /* RSDFDatePickerView.h in Headers */,
+				BC149D371BBC12EA008D033B /* RSDFDatePickerCollectionViewLayout.h in Headers */,
+				BC149D3A1BBC12EA008D033B /* RSDFDatePickerDayCell.h in Headers */,
+				BC149D1C1BBC12A3008D033B /* RSDayFlow.h in Headers */,
+				BC149D421BBC12EA008D033B /* RSDFDatePickerView+Protected.h in Headers */,
+				BC149D331BBC12EA008D033B /* NSCalendar+RSDFAdditions.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		BC149D171BBC12A3008D033B /* RSDayFlow */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BC149D201BBC12A3008D033B /* Build configuration list for PBXNativeTarget "RSDayFlow" */;
+			buildPhases = (
+				BC149D131BBC12A3008D033B /* Sources */,
+				BC149D141BBC12A3008D033B /* Frameworks */,
+				BC149D151BBC12A3008D033B /* Headers */,
+				BC149D161BBC12A3008D033B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RSDayFlow;
+			productName = RSDayFlow;
+			productReference = BC149D181BBC12A3008D033B /* RSDayFlow.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		BC149D0F1BBC12A3008D033B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				CLASSPREFIX = RSDF;
+				LastUpgradeCheck = 0700;
+				ORGANIZATIONNAME = "Ruslan Skorb";
+				TargetAttributes = {
+					BC149D171BBC12A3008D033B = {
+						CreatedOnToolsVersion = 7.0.1;
+					};
+				};
+			};
+			buildConfigurationList = BC149D121BBC12A3008D033B /* Build configuration list for PBXProject "RSDayFlow" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = BC149D0E1BBC12A3008D033B;
+			productRefGroup = BC149D191BBC12A3008D033B /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				BC149D171BBC12A3008D033B /* RSDayFlow */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		BC149D161BBC12A3008D033B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		BC149D131BBC12A3008D033B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BC149D341BBC12EA008D033B /* NSCalendar+RSDFAdditions.m in Sources */,
+				BC149D411BBC12EA008D033B /* RSDFDatePickerView.m in Sources */,
+				BC149D361BBC12EA008D033B /* RSDFDatePickerCollectionView.m in Sources */,
+				BC149D381BBC12EA008D033B /* RSDFDatePickerCollectionViewLayout.m in Sources */,
+				BC149D3D1BBC12EA008D033B /* RSDFDatePickerDaysOfWeekView.m in Sources */,
+				BC149D3F1BBC12EA008D033B /* RSDFDatePickerMonthHeader.m in Sources */,
+				BC149D3B1BBC12EA008D033B /* RSDFDatePickerDayCell.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		BC149D1E1BBC12A3008D033B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		BC149D1F1BBC12A3008D033B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		BC149D211BBC12A3008D033B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = RSDayFlow/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.ruslanskorb.RSDayFlow;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		BC149D221BBC12A3008D033B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = RSDayFlow/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.ruslanskorb.RSDayFlow;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		BC149D121BBC12A3008D033B /* Build configuration list for PBXProject "RSDayFlow" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC149D1E1BBC12A3008D033B /* Debug */,
+				BC149D1F1BBC12A3008D033B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BC149D201BBC12A3008D033B /* Build configuration list for PBXNativeTarget "RSDayFlow" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC149D211BBC12A3008D033B /* Debug */,
+				BC149D221BBC12A3008D033B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = BC149D0F1BBC12A3008D033B /* Project object */;
+}

--- a/RSDayFlow.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/RSDayFlow.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:RSDayFlow.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/RSDayFlow.xcodeproj/xcshareddata/xcschemes/RSDayFlow.xcscheme
+++ b/RSDayFlow.xcodeproj/xcshareddata/xcschemes/RSDayFlow.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0700"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BC149D171BBC12A3008D033B"
+               BuildableName = "RSDayFlow.framework"
+               BlueprintName = "RSDayFlow"
+               ReferencedContainer = "container:RSDayFlow.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BC149D171BBC12A3008D033B"
+            BuildableName = "RSDayFlow.framework"
+            BlueprintName = "RSDayFlow"
+            ReferencedContainer = "container:RSDayFlow.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BC149D171BBC12A3008D033B"
+            BuildableName = "RSDayFlow.framework"
+            BlueprintName = "RSDayFlow"
+            ReferencedContainer = "container:RSDayFlow.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/RSDayFlow/Info.plist
+++ b/RSDayFlow/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.2.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/RSDayFlow/RSDFDatePickerDayCell.h
+++ b/RSDayFlow/RSDFDatePickerDayCell.h
@@ -24,7 +24,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "RSDFDatePickerDate.h"
+#import <RSDayFlow/RSDFDatePickerDate.h>
 
 /**
  The `RSDFDatePickerDayCell` is a cell which used to display a day in the date picker view.

--- a/RSDayFlow/RSDFDatePickerMonthHeader.h
+++ b/RSDayFlow/RSDFDatePickerMonthHeader.h
@@ -24,7 +24,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "RSDFDatePickerDate.h"
+#import <RSDayFlow/RSDFDatePickerDate.h>
 
 /**
  The `RSDFDatePickerMonthHeader` is a reusable view which used to display a month and year in the date picker view.

--- a/RSDayFlow/RSDFDatePickerView+Protected.h
+++ b/RSDayFlow/RSDFDatePickerView+Protected.h
@@ -23,7 +23,7 @@
 // THE SOFTWARE.
 //
 
-#import "RSDFDatePickerView.h"
+#import <RSDayFlow/RSDFDatePickerView.h>
 
 /**
  The methods in the RSDFDatePickerViewProtectedMethods category

--- a/RSDayFlow/RSDayFlow.h
+++ b/RSDayFlow/RSDayFlow.h
@@ -27,16 +27,20 @@
  `RSDayFlow` is an iOS 7 Calendar with Infinite Scrolling.
  */
 
-#ifndef RSDayFlow_RSDayFlow_h
-#define RSDayFlow_RSDayFlow_h
+#import <UIKit/UIKit.h>
 
-#import "RSDFDatePickerView.h"
-#import "RSDFDatePickerView+Protected.h"
-#import "RSDFDatePickerDate.h"
-#import "RSDFDatePickerDaysOfWeekView.h"
-#import "RSDFDatePickerCollectionView.h"
-#import "RSDFDatePickerCollectionViewLayout.h"
-#import "RSDFDatePickerMonthHeader.h"
-#import "RSDFDatePickerDayCell.h"
+//! Project version number for Test.
+FOUNDATION_EXPORT double TestVersionNumber;
 
-#endif
+//! Project version string for Test.
+FOUNDATION_EXPORT const unsigned char TestVersionString[];
+
+#import <RSDayFlow/RSDFDatePickerView.h>
+#import <RSDayFlow/RSDFDatePickerView+Protected.h>
+#import <RSDayFlow/RSDFDatePickerDate.h>
+#import <RSDayFlow/RSDFDatePickerDaysOfWeekView.h>
+#import <RSDayFlow/RSDFDatePickerCollectionView.h>
+#import <RSDayFlow/RSDFDatePickerCollectionViewLayout.h>
+#import <RSDayFlow/RSDFDatePickerMonthHeader.h>
+#import <RSDayFlow/RSDFDatePickerDayCell.h>
+


### PR DESCRIPTION
I've created a simple Xcode project with a Framework target for iOS and added your sources to it (adjusting a little bit the imports in the headers).

With that your library can be built using Carthage, other than CocoaPods.