### PR TITLE
Fix end date

### DIFF
--- a/RSDayFlow/RSDFDatePickerView.m
+++ b/RSDayFlow/RSDFDatePickerView.m
@@ -398,7 +398,7 @@ static NSString * const RSDFDatePickerViewDayCellIdentifier = @"RSDFDatePickerVi
     }
     
     if (self.endDate) {
-        _toDate = [self dateWithFirstDayOfMonth:[self dateByMovingToEndOfMonth:self.endDate]];
+        _toDate = [self dateWithFirstDayOfNextMonth:self.endDate];
     } else {
         _toDate = [self dateWithFirstDayOfMonth:[self.calendar dateByAddingComponents:((^{
             NSDateComponents *components = [NSDateComponents new];
@@ -416,11 +416,12 @@ static NSString * const RSDFDatePickerViewDayCellIdentifier = @"RSDFDatePickerVi
                                                object:nil];
 }
 
-- (NSDate *)dateByMovingToEndOfMonth:(NSDate *)date
+- (NSDate *)dateWithFirstDayOfNextMonth:(NSDate *)date
 {
     NSDateComponents *components = [self.calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:date];
     
     components.month = components.month + 1;
+    components.day = 1;
     return [self.calendar dateFromComponents:components];
 }
 

--- a/RSDayFlow/RSDFDatePickerView.m
+++ b/RSDayFlow/RSDFDatePickerView.m
@@ -388,7 +388,7 @@ static NSString * const RSDFDatePickerViewDayCellIdentifier = @"RSDFDatePickerVi
     NSDate *now = [self.calendar dateFromComponents:nowYearMonthComponents];
     
     if (self.startDate) {
-        _fromDate = [self dateWithFirstDayOfMonth:[self dateWithFirstDayOfMonth:self.startDate]];
+        _fromDate = [self dateWithFirstDayOfMonth:self.startDate];
     } else {
         _fromDate = [self dateWithFirstDayOfMonth:[self.calendar dateByAddingComponents:((^{
             NSDateComponents *components = [NSDateComponents new];


### PR DESCRIPTION
Setting the `toDate` using the following code results in a bug.
```
_toDate = [self dateWithFirstDayOfMonth:[self dateByMovingToEndOfMonth:self.endDate]];
```

First of all is the method `dateByMovingToEndOfMonth` named incorrect since it doesn't go to the end of the month but goes to the next month with the same date.

What above code should do is go to the next month and then go to the first day of that month.

The bug occurs when passing in a date on a day that the next month doesn't have. For example passing the 31st of March doesn't resolve first into the 30th of April and then the 1st of April as it should. Instead it first resolves to the 1st of May since April doesn't have day 31 and then stays on the 1st of May.

This is fixed by settings the date components next month and then first day within the same operation without transforming it to a date in between. Also I fixed the name of the method.