### PR TITLE
Allow customizing dayOffOfWeekLabelFont

### DIFF
--- a/RSDayFlow/RSDFDatePickerDaysOfWeekView.h
+++ b/RSDayFlow/RSDFDatePickerDaysOfWeekView.h
@@ -114,6 +114,19 @@ typedef NS_ENUM (NSUInteger, RSDFDaysOfWeekDisplayStyle) {
 - (UIFont *)dayOfWeekLabelFont;
 
 /**
+ The font for the label of the day off of the week. Default value depends on the interface idiom and the interface orientation.
+
+ `UIUserInterfaceIdiomPhone`:
+    - `UIInterfaceOrientationPortrait` or `UIInterfaceOrientationPortraitUpsideDown`: `[UIFont fontWithName:@"HelveticaNeue-Light" size:10.0]`
+    - Other: `[UIFont fontWithName:@"HelveticaNeue-Light" size:12.0]`
+ Other:
+    - Any: `[UIFont fontWithName:@"HelveticaNeue-Light" size:16.0]`
+
+ @discussion Can be overridden in subclasses for customization.
+ */
+- (UIFont *)dayOffOfWeekLabelFont;
+
+/**
  The text color for the label of the weekday. Default value is [UIColor blackColor].
  
  @discussion Can be overridden in subclasses for customization.

--- a/RSDayFlow/RSDFDatePickerDaysOfWeekView.m
+++ b/RSDayFlow/RSDFDatePickerDaysOfWeekView.m
@@ -238,17 +238,19 @@
             UIColor *dayOfWeekLabelBackgroundColor = [UIColor clearColor];
             UIColor *dayOfWeekLabelTextColor = [self dayOfWeekLabelTextColor];
             UIColor *dayOffOfWeekLabelTextColor = [self dayOffOfWeekLabelTextColor];
+            UIFont *dayOffOfWeekLabelFont = [self dayOffOfWeekLabelFont];
             
             NSMutableArray *weekdayLabels = [NSMutableArray arrayWithCapacity:[symbolsToUse count]];
             [symbolsToUse enumerateObjectsUsingBlock:^(NSString *weekdaySymbol, NSUInteger idx, BOOL *stop) {
                 UILabel *weekdayLabel = [[UILabel alloc] init];
                 weekdayLabel.textAlignment = NSTextAlignmentCenter;
                 weekdayLabel.backgroundColor = dayOfWeekLabelBackgroundColor;
-                weekdayLabel.font = dayOfWeekLabelFont;
                 NSUInteger originalIndexOfWeekdaySymbol = [self originalIndexOfWeekdaySymbolFromReorderedIndex:[symbolsToUse indexOfObjectIdenticalTo:weekdaySymbol]];
                 if (originalIndexOfWeekdaySymbol != self.originalIndexOfSaturdaySymbol && originalIndexOfWeekdaySymbol != self.originalIndexOfSundaySymbol) {
+                    weekdayLabel.font = dayOfWeekLabelFont;
                     weekdayLabel.textColor = dayOfWeekLabelTextColor;
                 } else {
+                    weekdayLabel.font = dayOffOfWeekLabelFont;
                     weekdayLabel.textColor = dayOffOfWeekLabelTextColor;
                 }
                 weekdayLabel.text = weekdaySymbol;
@@ -312,6 +314,19 @@
 #pragma mark - Attributes of Subviews
 
 - (UIFont *)dayOfWeekLabelFont
+{
+    if ([self isPhone]) {
+        if ([self isPortraitInterfaceOrientation]) {
+            return [UIFont fontWithName:@"HelveticaNeue-Light" size:10.0];
+        } else {
+            return [UIFont fontWithName:@"HelveticaNeue-Light" size:12.0];
+        }
+    } else {
+        return [UIFont fontWithName:@"HelveticaNeue-Light" size:16.0];
+    }
+}
+
+- (UIFont *)dayOffOfWeekLabelFont
 {
     if ([self isPhone]) {
         if ([self isPortraitInterfaceOrientation]) {


### PR DESCRIPTION
Right now it's not possible to customize the font of "day off of week" labels. Since it's possible to change the color, I believe it should also be possible to change the font.