### PR TITLE
Fix non-modular header include error when imported from Swift

### DIFF
--- a/RSDayFlow.podspec
+++ b/RSDayFlow.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/ruslanskorb/RSDayFlow.git', :tag => s.version.to_s }
   s.platform     = :ios, '7.0'
   s.source_files = 'RSDayFlow'
+  s.private_header_files = 'RSDayFlow/RSDayFlow.h', 'RSDayFlow/*+Protected.h'
   s.frameworks = 'QuartzCore', 'UIKit'
   s.requires_arc = true
 end


### PR DESCRIPTION
Xcode 7.3 emits `include of non-modular header inside framework module` error when RSDayFlow is imported from Swift.
Another Swift pod cannot depend on RSDayFlow pod because automatic lint on `pod trunk push` fails.

`s.source_files = 'RSDayFlow'` in the podspec includes all headers in `RSDayFlow.h` and thus they will be exported in the CocoaPods-generated `RSDayFlow.modulemap`. We can mark them as private headers in the podspec.

```
    - NOTE  | xcodebuild:  Target Support Files/RSDayFlow/RSDayFlow-umbrella.h:4:9: note: in file included from Target Support Files/RSDayFlow/RSDayFlow-umbrella.h:4:
    - ERROR | xcodebuild:  RSDayFlow/RSDayFlow/RSDayFlow.h:33:9: error: include of non-modular header inside framework module 'RSDayFlow.RSDayFlow'
    - ERROR | xcodebuild:  RSDayFlow/RSDayFlow/RSDayFlow.h:34:9: error: include of non-modular header inside framework module 'RSDayFlow.RSDayFlow'
    - ERROR | xcodebuild:  RSDayFlow/RSDayFlow/RSDayFlow.h:35:9: error: include of non-modular header inside framework module 'RSDayFlow.RSDayFlow'
    - ERROR | xcodebuild:  RSDayFlow/RSDayFlow/RSDayFlow.h:36:9: error: include of non-modular header inside framework module 'RSDayFlow.RSDayFlow'
    - ERROR | xcodebuild:  RSDayFlow/RSDayFlow/RSDayFlow.h:37:9: error: include of non-modular header inside framework module 'RSDayFlow.RSDayFlow'
    - ERROR | xcodebuild:  RSDayFlow/RSDayFlow/RSDayFlow.h:38:9: error: include of non-modular header inside framework module 'RSDayFlow.RSDayFlow'
    - ERROR | xcodebuild:  RSDayFlow/RSDayFlow/RSDayFlow.h:39:9: error: include of non-modular header inside framework module 'RSDayFlow.RSDayFlow'
    - ERROR | xcodebuild:  RSDayFlow/RSDayFlow/RSDayFlow.h:40:9: error: include of non-modular header inside framework module 'RSDayFlow.RSDayFlow'
```