### PR TITLE
Customizable month header label text

### DIFF
--- a/RSDayFlow/RSDFDatePickerMonthHeader.h
+++ b/RSDayFlow/RSDFDatePickerMonthHeader.h
@@ -83,6 +83,15 @@
  */
 - (UIColor *)monthLabelTextColor;
 
+
+/**
+ The text for the label of the month. Default value is nil.
+ If the value is nil, RSDFDatePickerView sets dateLabel.text in default format.
+
+ @discussion Can be overridden in subclasses for customization.
+ */
+- (NSString *)monthLabelText;
+
 /**
  The text color for the label of the current month. Default value is [UIColor colorWithRed:32/255.0f green:135/255.0f blue:252/255.0f alpha:1.0f].
  

--- a/RSDayFlow/RSDFDatePickerMonthHeader.m
+++ b/RSDayFlow/RSDFDatePickerMonthHeader.m
@@ -104,6 +104,11 @@
     return [UIColor blackColor];
 }
 
+- (NSString *)monthLabelText
+{
+    return nil;
+}
+
 - (UIColor *)currentMonthLabelTextColor
 {
     return [UIColor colorWithRed:32/255.0f green:135/255.0f blue:252/255.0f alpha:1.0f];

--- a/RSDayFlow/RSDFDatePickerView.m
+++ b/RSDayFlow/RSDFDatePickerView.m
@@ -744,10 +744,14 @@ static NSString * const RSDFDatePickerViewDayCellIdentifier = @"RSDFDatePickerVi
         RSDFDatePickerDate date = [self pickerDateFromDate:formattedDate];
         
         monthHeader.date = date;
-        
-        NSString *monthString = [dateFormatter shortStandaloneMonthSymbols][date.month - 1];
-        monthHeader.dateLabel.text = [[NSString stringWithFormat:@"%@ %tu", monthString, date.year] uppercaseString];
-        
+
+        NSString *monthLabelText = [monthHeader monthLabelText];
+        if (!monthLabelText) {
+            NSString *monthString = [dateFormatter shortStandaloneMonthSymbols][date.month - 1];
+            monthLabelText = [[NSString stringWithFormat:@"%@ %tu", monthString, date.year] uppercaseString];
+        }
+        monthHeader.dateLabel.text = monthLabelText;
+
         RSDFDatePickerDate today = [self pickerDateFromDate:_today];
         if ( (today.month == date.month) && (today.year == date.year) ) {
             monthHeader.currentMonth = YES;


### PR DESCRIPTION
Allows customize for month header label text like other month label attributes.
For compatibility, `monthLabelText` return nil in default, and RSDFDatePickerView sets the label text just like before.

With this PR, month header subclasses can override label text value like this:

```
- (NSString *)monthLabelText
{
    return [NSString stringWithFormat:@"%04tu/%02tu", self.date.year, self.date.month];
}
```