### PR TITLE
Default image view frames taking into account screen scale

### DIFF
--- a/RSDayFlow/RSDFDatePickerDayCell.m
+++ b/RSDayFlow/RSDFDatePickerDayCell.m
@@ -25,6 +25,10 @@
 
 #import "RSDFDatePickerDayCell.h"
 
+CGFloat roundOnBase(CGFloat x, CGFloat base) {
+    return round(x * base) / base;
+}
+
 @interface RSDFDatePickerDayCell ()
 
 + (NSCache *)imageCache;
@@ -121,12 +125,12 @@
 
 - (CGRect)dividerImageViewFrame
 {
-    return CGRectMake(0.0f, 0.0f, CGRectGetWidth(self.frame) + 3.0f, 0.5f);
+    return CGRectMake(0.0f, 0.0f, CGRectGetWidth(self.frame) + 3.0f, roundOnBase(0.5f, [UIScreen mainScreen].scale));
 }
 
 - (CGRect)markImageViewFrame
 {
-    return CGRectMake(CGRectGetWidth(self.frame) / 2 - 4.5f, 45.5f, 9.0f, 9.0f);
+    return CGRectMake(roundOnBase(CGRectGetWidth(self.frame) / 2 - 4.5f, [UIScreen mainScreen].scale), roundOnBase(45.5f, [UIScreen mainScreen].scale), 9.0f, 9.0f);
 }
 
 - (UIImage *)markImage
@@ -183,7 +187,7 @@
 
 - (CGRect)selectedImageViewFrame
 {
-    return CGRectMake(CGRectGetWidth(self.frame) / 2 - 17.5f, 5.5f, 35.0f, 35.0f);
+    return CGRectMake(roundOnBase(CGRectGetWidth(self.frame) / 2 - 17.5f, [UIScreen mainScreen].scale), roundOnBase(5.5, [UIScreen mainScreen].scale), 35.0f, 35.0f);
 }
 
 - (void)setMarkImage:(UIImage *)markImage


### PR DESCRIPTION
Hardcoded image frames didn't take into account screen scale and was tied to 2x scale. 1x was majorly cropped and 3x was slightly cropped:
<img width="48" alt="screen shot 2016-06-29 at 11 20 38" src="https://cloud.githubusercontent.com/assets/3721061/16446211/395bdc56-3def-11e6-8779-4fca531bd6fd.png"><img width="51" alt="screen shot 2016-06-29 at 11 20 05" src="https://cloud.githubusercontent.com/assets/3721061/16446214/3b2b0502-3def-11e6-84a6-c5a647f619e7.png">

Fix rounds values in specified (screen scale) base:
<img width="46" alt="screen shot 2016-06-29 at 11 21 12" src="https://cloud.githubusercontent.com/assets/3721061/16446237/5724c626-3def-11e6-9854-f77a8ece4b61.png"><img width="45" alt="screen shot 2016-06-29 at 11 21 36" src="https://cloud.githubusercontent.com/assets/3721061/16446243/5a3da15c-3def-11e6-8916-b5ff8cbd4126.png">

