### PR TITLE
Fix redefinition of module RSDayFlow error

### DIFF
--- a/RSDayFlow/NSCalendar+RSDFAdditions.m
+++ b/RSDayFlow/NSCalendar+RSDFAdditions.m
@@ -23,7 +23,7 @@
 // THE SOFTWARE.
 //
 
-#import "NSCalendar+RSDFAdditions.h"
+#import <RSDayFlow/NSCalendar+RSDFAdditions.h>
 
 @implementation NSCalendar (RSDFAdditions)
 

--- a/RSDayFlow/RSDFDatePickerCollectionView.m
+++ b/RSDayFlow/RSDFDatePickerCollectionView.m
@@ -23,8 +23,8 @@
 // THE SOFTWARE.
 //
 
-#import "RSDFDatePickerCollectionView.h"
-#import "RSDFDatePickerCollectionViewLayout.h"
+#import <RSDayFlow/RSDFDatePickerCollectionView.h>
+#import <RSDayFlow/RSDFDatePickerCollectionViewLayout.h>
 
 @implementation RSDFDatePickerCollectionView
 

--- a/RSDayFlow/RSDFDatePickerCollectionViewLayout.m
+++ b/RSDayFlow/RSDFDatePickerCollectionViewLayout.m
@@ -23,7 +23,7 @@
 // THE SOFTWARE.
 //
 
-#import "RSDFDatePickerCollectionViewLayout.h"
+#import <RSDayFlow/RSDFDatePickerCollectionViewLayout.h>
 
 @interface RSDFDatePickerCollectionViewLayout ()
 

--- a/RSDayFlow/RSDFDatePickerDayCell.m
+++ b/RSDayFlow/RSDFDatePickerDayCell.m
@@ -23,7 +23,7 @@
 // THE SOFTWARE.
 //
 
-#import "RSDFDatePickerDayCell.h"
+#import <RSDayFlow/RSDFDatePickerDayCell.h>
 
 CGFloat roundOnBase(CGFloat x, CGFloat base) {
     return round(x * base) / base;

--- a/RSDayFlow/RSDFDatePickerDaysOfWeekView.m
+++ b/RSDayFlow/RSDFDatePickerDaysOfWeekView.m
@@ -23,8 +23,8 @@
 // THE SOFTWARE.
 //
 
-#import "RSDFDatePickerDaysOfWeekView.h"
-#import "NSCalendar+RSDFAdditions.h"
+#import <RSDayFlow/RSDFDatePickerDaysOfWeekView.h>
+#import <RSDayFlow/NSCalendar+RSDFAdditions.h>
 
 @interface RSDFDatePickerDaysOfWeekView ()
 

--- a/RSDayFlow/RSDFDatePickerMonthHeader.m
+++ b/RSDayFlow/RSDFDatePickerMonthHeader.m
@@ -23,7 +23,7 @@
 // THE SOFTWARE.
 //
 
-#import "RSDFDatePickerMonthHeader.h"
+#import <RSDayFlow/RSDFDatePickerMonthHeader.h>
 
 @implementation RSDFDatePickerMonthHeader
 

--- a/RSDayFlow/RSDFDatePickerView.m
+++ b/RSDayFlow/RSDFDatePickerView.m
@@ -24,14 +24,14 @@
 //
 
 #import <QuartzCore/QuartzCore.h>
-#import "RSDFDatePickerCollectionView.h"
-#import "RSDFDatePickerCollectionViewLayout.h"
-#import "RSDFDatePickerDate.h"
-#import "RSDFDatePickerDayCell.h"
-#import "RSDFDatePickerMonthHeader.h"
-#import "RSDFDatePickerView.h"
-#import "RSDFDatePickerDaysOfWeekView.h"
-#import "NSCalendar+RSDFAdditions.h"
+#import <RSDayFlow/RSDFDatePickerCollectionView.h>
+#import <RSDayFlow/RSDFDatePickerCollectionViewLayout.h>
+#import <RSDayFlow/RSDFDatePickerDate.h>
+#import <RSDayFlow/RSDFDatePickerDayCell.h>
+#import <RSDayFlow/RSDFDatePickerMonthHeader.h>
+#import <RSDayFlow/RSDFDatePickerView.h>
+#import <RSDayFlow/RSDFDatePickerDaysOfWeekView.h>
+#import <RSDayFlow/NSCalendar+RSDFAdditions.h>
 
 static NSString * const RSDFDatePickerViewMonthHeaderIdentifier = @"RSDFDatePickerViewMonthHeaderIdentifier";
 static NSString * const RSDFDatePickerViewDayCellIdentifier = @"RSDFDatePickerViewDayCellIdentifier";


### PR DESCRIPTION
Xcode 8.3 beta 1 (8W109m) emits error `redefinition of module RSDayFlow` (also reproducible RSDayFlow Example project).
This patch fixes the error. It should build also with Xcode 8.2.

Possibly the error caused by the **beta Xcode**, however, similar problems seem to be fixed by `#import` changes.

https://github.com/CocoaPods/CocoaPods/search?q=redefinition&type=Issues&utf8=✓
