### PR TITLE
Added "overloaded" reload function that includes a completion block.

### DIFF
--- a/RSDayFlow/RSDFDatePickerView.h
+++ b/RSDayFlow/RSDFDatePickerView.h
@@ -135,6 +135,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)reloadData;
 
+///-----------------------------------------------
+/// @name Reloading the Data with completion block
+///-----------------------------------------------
+
+/**
+ Reloads all of the data for the date picker view, call compltion block when done
+ 
+ @discussion Discard the dataSource and delegate data and requery as necessary.
+ */
+- (void)reloadDataWithCompletion:(void (^)(BOOL))completionBlock;
+
 ///------------------------------------
 /// @name Accessing Classes of Subviews
 ///------------------------------------

--- a/RSDayFlow/RSDFDatePickerView.m
+++ b/RSDayFlow/RSDFDatePickerView.m
@@ -272,6 +272,16 @@ static NSString * const RSDFDatePickerViewDayCellIdentifier = @"RSDFDatePickerVi
     [self.collectionView reloadData];
 }
 
+- (void)reloadDataWithCompletion:(void (^)(BOOL))completionBlock
+{
+    [self.collectionView reloadData];
+    [_collectionView performBatchUpdates:^{
+        
+    } completion:^(BOOL finished) {
+        completionBlock(finished);
+    }];
+}
+
 - (void)scrollToDate:(NSDate *)date animated:(BOOL)animated
 {
     if (self.startDate && [date compare:self.startDate] == NSOrderedAscending) {


### PR DESCRIPTION
I was in a situation where i needed to select a data after the collectionview did finished load. As the collectionview was not public i decided to make a new reload function that take a block as parameter. This block is called when the collectionview is finished loading. This could also be used if you would like to utilize a spinner that you want to remove after load is finished.

My first solution was to just return the collectionview in the current reload function. But as it was already private it seemed like a poor solution. So i decided to add a new function to keep it clean.

I have implemented this solution in my own project, and it works fine.

Im not 100% sure if there was any other way in the current project to achieve this, but i was not able to find one.

thank for a awesome component that i love to use!

