### PR TITLE
Support iOS 13+ dark mode

### DIFF
--- a/RSDayFlow/RSDFDatePickerCollectionView.m
+++ b/RSDayFlow/RSDFDatePickerCollectionView.m
@@ -80,7 +80,10 @@
 
 - (UIColor *)selfBackgroundColor
 {
-    return [UIColor whiteColor];
+  if (@available(iOS 13, *)) {
+    return [UIColor groupTableViewBackgroundColor];
+  }
+  return [UIColor whiteColor];
 }
 
 @end

--- a/RSDayFlow/RSDFDatePickerDayCell.m
+++ b/RSDayFlow/RSDFDatePickerDayCell.m
@@ -342,7 +342,10 @@ CGFloat roundOnBase(CGFloat x, CGFloat base) {
 
 - (UIColor *)dayLabelTextColor
 {
-    return [UIColor blackColor];
+  if (@available(iOS 13, *)) {
+    return [UIColor labelColor];
+  }
+  return [UIColor blackColor];
 }
 
 - (UIColor *)dayOffLabelTextColor

--- a/RSDayFlow/RSDFDatePickerDaysOfWeekView.m
+++ b/RSDayFlow/RSDFDatePickerDaysOfWeekView.m
@@ -279,7 +279,10 @@
 
 - (UIColor *)selfBackgroundColor
 {
-    return [UIColor colorWithRed:248.0/255 green:248.0/255 blue:248.0/255 alpha:1.0];
+  if (@available(iOS 13, *)) {
+    return [UIColor groupTableViewBackgroundColor];
+  }
+  return [UIColor colorWithRed:248.0/255 green:248.0/255 blue:248.0/255 alpha:1.0];
 }
 
 #pragma mark - Attributes of the Layout
@@ -341,7 +344,10 @@
 
 - (UIColor *)dayOfWeekLabelTextColor
 {
-    return [UIColor blackColor];
+  if (@available(iOS 13, *)) {
+    return [UIColor labelColor];
+  }
+  return [UIColor blackColor];
 }
 
 - (UIColor *)dayOffOfWeekLabelTextColor

--- a/RSDayFlow/RSDFDatePickerMonthHeader.m
+++ b/RSDayFlow/RSDFDatePickerMonthHeader.m
@@ -114,7 +114,10 @@
 
 - (UIColor *)monthLabelTextColor
 {
-    return [UIColor blackColor];
+  if (@available(iOS 13, *)) {
+    return [UIColor labelColor];
+  }
+  return [UIColor blackColor];
 }
 
 - (UIColor *)currentMonthLabelTextColor


### PR DESCRIPTION
iOS 13+ starts to support dark mode.
Use [UIColor labelColor] and [UIColor groupTableViewBackgroundColor] for common text and background color to auto adapt to light/dark mode.